### PR TITLE
Make App a context manager

### DIFF
--- a/pylibui/core.py
+++ b/pylibui/core.py
@@ -17,7 +17,7 @@ class App:
         libui.uiInit(options)
 
     def __enter__(self):
-     self.start()
+        self.start()
      
     def start(self):
         """
@@ -30,7 +30,6 @@ class App:
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.stop()
         self.close()
-        
 
     def stop(self):
         """

--- a/pylibui/core.py
+++ b/pylibui/core.py
@@ -16,6 +16,9 @@ class App:
         options = libui.uiInitOptions()
         libui.uiInit(options)
 
+    def __enter__(self):
+     self.start()
+     
     def start(self):
         """
         Starts the application main loop.
@@ -23,6 +26,11 @@ class App:
         :return: None
         """
         libui.uiMain()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.stop()
+        self.close()
+        
 
     def stop(self):
         """


### PR DESCRIPTION
This means it can be used either as it is now unchanged or like this:

with libui.App():
    ... # code

Note that (1) the build instructions for libui appear to be wrong "make" vs "cmake ."; and (2) I can't build libui because of a bug in it or Ubuntu 14.04's cmake I don't know which. So this change is untested.

PS somehow the indentation of the __enter__() went wrong, sorry.