### PR TITLE
enumerate defaults to 0-based but can do n-based

### DIFF
--- a/scripts/bindings.py
+++ b/scripts/bindings.py
@@ -23,8 +23,8 @@ def return_lines(filename, start, end):
 
     with open(filename, 'r') as fin:
 
-        for lineno, line in enumerate(fin):
-            if start <= lineno + 1 <= end:
+        for lineno, line in enumerate(fin, 1):
+            if start <= lineno <= end:
                 lines.append(line.strip())
 
     return lines


### PR DESCRIPTION
Personally, I'd never write open(filename, 'r'); I'd always specify binary or an encoding, e.g. open(filename, 'rt', encoding='utf-8').

Also, why can't generic_head() just use a triple-quoted string with literal newlines?

return """
# Python wrapper for libui

import ctypes
from . import clibui


"""

Same with generic_struct(), etc.

I assume the sections are line numbers. Wouldn't it be more reliable to use regex patterns to find beginning/end?