### PR TITLE
Fixed lineno error in return_lines function

### DIFF
--- a/scripts/bindings.py
+++ b/scripts/bindings.py
@@ -24,7 +24,7 @@ def return_lines(filename, start, end):
     with open(filename, 'r') as fin:
 
         for lineno, line in enumerate(fin):
-            if start <= lineno + 1 <= end:
+            if start <= lineno <= end:
                 lines.append(line.strip())
 
     return lines


### PR DESCRIPTION
New version of the lines array for combobox:
![bindings](https://cloud.githubusercontent.com/assets/16865058/19490655/aeb2d85c-9578-11e6-854e-dd5e9cf9f3a0.png)

Fixes #16 