### PR TITLE
added uiEntry + fixed a wrong function call

### DIFF
--- a/examples/entry.py
+++ b/examples/entry.py
@@ -1,0 +1,46 @@
+"""
+ Shows three entries :
+ - a simple entry
+ - a password entry
+ - a search entry
+
+"""
+
+from pylibui.core import App
+from pylibui.controls import (Window, Entry, SearchEntry, PasswordEntry,
+                              VerticalBox)
+
+
+class MyWindow(Window):
+
+    def onClose(self, data):
+        super().onClose(data)
+        app.stop()
+
+
+class MyEntry(Entry):
+
+    def onChanged(self, data):
+        print('entry changed!')
+
+
+app = App()
+
+window = MyWindow('Entry example')
+window.setMargined(10)
+
+entry = MyEntry()
+search_entry = SearchEntry()
+password_entry = PasswordEntry()
+
+vbox = VerticalBox()
+vbox.setPadded(10)
+vbox.append(entry)
+vbox.append(search_entry)
+vbox.append(password_entry)
+
+window.setChild(vbox)
+window.show()
+
+app.start()
+app.close()

--- a/examples/entry.py
+++ b/examples/entry.py
@@ -43,4 +43,4 @@ window.setChild(vbox)
 window.show()
 
 app.start()
-app.close()
+# app.close() # SEE https://github.com/joaoventura/pylibui/issues/18

--- a/examples/entry.py
+++ b/examples/entry.py
@@ -27,14 +27,14 @@ class MyEntry(Entry):
 app = App()
 
 window = MyWindow('Entry example')
-window.setMargined(10)
+window.setMargined(1)
 
 entry = MyEntry()
 search_entry = SearchEntry()
 password_entry = PasswordEntry()
 
 vbox = VerticalBox()
-vbox.setPadded(10)
+vbox.setPadded(1)
 vbox.append(entry)
 vbox.append(search_entry)
 vbox.append(password_entry)

--- a/pylibui/controls/__init__.py
+++ b/pylibui/controls/__init__.py
@@ -7,6 +7,7 @@ from .box import Box, HorizontalBox, VerticalBox
 from .button import Button
 from .control import Control
 from .checkbox import Checkbox
+from .entry import Entry, PasswordEntry, SearchEntry
 from .label import Label
 from .progressbar import ProgressBar
 from .slider import Slider

--- a/pylibui/controls/entry.py
+++ b/pylibui/controls/entry.py
@@ -1,0 +1,107 @@
+"""
+ Python wrapper for libui.
+
+"""
+
+from pylibui import libui
+from .control import Control
+
+
+class BaseEntry(Control):
+
+    def setText(self, text):
+        """
+        Sets the text of the entry.
+
+        :param text: the text of the entry
+        :return: None
+        """
+        libui.uiEntrySetText(self.control, text)
+
+    def getText(self):
+        """
+        Returns the text of the entry.
+
+        :return: string
+        """
+        return libui.uiEntryText(self.control)
+
+    def setReadOnly(self, read_only):
+        """
+        Sets whether the entry is read only or not.
+
+        :param read_only: bool
+        :return: None
+        """
+        libui.uiEntrySetReadOnly(self.control, read_only)
+
+    def getReadOnly(self):
+        """
+        Sets whether the entry is read only or not.
+
+        :return: bool
+        """
+        return libui.uiEntryReadOnly(self.control)
+
+    def onChanged(self, data):
+        """
+        Executes when the entry is changed.
+
+        :param data: data
+        :return: None
+        """
+        pass
+
+
+class Entry(BaseEntry):
+
+    def __init__(self):
+        """
+        Creates a new entry.
+
+        """
+        super().__init__()
+        self.control = libui.uiNewEntry()
+
+        def handler(window, data):
+            self.onChanged(data)
+            return 0
+
+        self.changedHandler = libui.uiEntryOnChanged(self.control, handler,
+                                                     None)
+
+
+class PasswordEntry(Entry):
+
+    def __init__(self):
+        """
+        Creates a new password entry.
+
+        """
+        super().__init__()
+        self.control = libui.uiNewPasswordEntry()
+
+        def handler(window, data):
+            self.onChanged(data)
+            return 0
+
+        self.changedHandler = libui.uiEntryOnChanged(self.control, handler,
+                                                     None)
+
+
+class SearchEntry(Entry):
+
+    def __init__(self):
+        """
+        Creates a new search entry.
+
+        """
+        super().__init__()
+        self.control = libui.uiNewSearchEntry()
+
+        def handler(window, data):
+            self.onChanged(data)
+            return 0
+
+        self.changedHandler = libui.uiEntryOnChanged(self.control, handler,
+                                                     None)

--- a/pylibui/controls/entry.py
+++ b/pylibui/controls/entry.py
@@ -13,7 +13,7 @@ class BaseEntry(Control):
         """
         Sets the text of the entry.
 
-        :param text: the text of the entry
+        :param text: string
         :return: None
         """
         libui.uiEntrySetText(self.control, text)
@@ -37,7 +37,7 @@ class BaseEntry(Control):
 
     def getReadOnly(self):
         """
-        Sets whether the entry is read only or not.
+        Returns whether the entry is read only or not.
 
         :return: bool
         """

--- a/pylibui/libui/__init__.py
+++ b/pylibui/libui/__init__.py
@@ -29,6 +29,7 @@ from .box import *
 from .button import *
 from .control import *
 from .checkbox import *
+from .entry import *
 from .label import *
 from .main import *
 from .progressbar import *

--- a/pylibui/libui/checkbox.py
+++ b/pylibui/libui/checkbox.py
@@ -66,7 +66,7 @@ def uiCheckboxOnToggled(checkbox, callback, data):
         ctypes.c_int, ctypes.POINTER(uiCheckbox), ctypes.c_void_p)
     c_callback = c_type(callback)
 
-    clibui.uiButtonOnClicked(checkbox, c_callback, data)
+    clibui.uiCheckboxOnToggled(checkbox, c_callback, data)
 
     return c_callback
 

--- a/pylibui/libui/entry.py
+++ b/pylibui/libui/entry.py
@@ -1,0 +1,138 @@
+"""
+ Python wrapper for libui.
+
+"""
+
+import ctypes
+from . import clibui
+
+
+class uiEntry(ctypes.Structure):
+    """Wrapper for the uiEntry C struct."""
+
+    pass
+
+
+def uiEntryPointer(obj):
+    """
+    Casts an object to uiEntry pointer type.
+
+    :param obj: a generic object
+    :return: uiEntry
+    """
+
+    return ctypes.cast(obj, ctypes.POINTER(uiEntry))
+
+
+# - char *uiEntryText(uiEntry *e);
+def uiEntryText(entry):
+    """
+    Returns the text of the entry.
+
+    :param entry: uiEntry
+    :return: string
+    """
+
+    clibui.uiEntryText.restype = ctypes.c_char_p
+    text = clibui.uiEntryText(entry)
+
+    return text.decode()
+
+
+# - void uiEntrySetText(uiEntry *e, const char *text);
+def uiEntrySetText(entry, text):
+    """
+    Sets the text of the entry.
+
+    :param entry: uiEntry
+    :param text: string
+    :return: None
+    """
+
+    clibui.uiEntrySetText(entry, bytes(text, 'utf-8'))
+
+
+# - void uiEntryOnChanged(uiEntry *e, void (*f)(uiEntry *e, void *data), void *data);
+def uiEntryOnChanged(entry, callback, data):
+    """
+    Executes the callback function on entry change.
+
+    :param entry: uiEntry
+    :param callback: function
+    :param data: data
+    :return: reference to C callback function
+    """
+    c_type = ctypes.CFUNCTYPE(
+        ctypes.c_int, ctypes.POINTER(uiEntry), ctypes.c_void_p)
+    c_callback = c_type(callback)
+
+    clibui.uiEntryOnChanged(entry, c_callback, data)
+
+    return c_callback
+
+
+# - int uiEntryReadOnly(uiEntry *e);
+def uiEntryReadOnly(entry):
+    """
+    Returns whether the entry is read only or not.
+
+    :param entry: uiEntry
+    :return: string
+    """
+
+    return bool(clibui.uiEntryReadOnly(entry))
+
+
+# - void uiEntrySetReadOnly(uiEntry *e, int readonly);
+def uiEntrySetReadOnly(entry, read_only):
+    """
+    Sets whether the entry is read only or not.
+
+    :param entry: uiEntry
+    :param read_only: bool
+    :return: None
+    """
+
+    clibui.uiEntrySetReadOnly(entry, read_only)
+
+
+# - uiEntry *uiNewEntry(void);
+def uiNewEntry():
+    """
+    Creates a new entry.
+
+    :return: uiEntry
+    """
+
+    # Set return type
+    clibui.uiNewEntry.restype = ctypes.POINTER(uiEntry)
+
+    return clibui.uiNewEntry()
+
+
+# uiEntry *uiNewPasswordEntry(void);
+def uiNewPasswordEntry():
+    """
+    Creates a new password entry.
+
+    :return: uiEntry
+    """
+
+    # Set return type
+    clibui.uiNewPasswordEntry.restype = ctypes.POINTER(uiEntry)
+
+    return clibui.uiNewPasswordEntry()
+
+
+# uiEntry *uiNewSearchEntry(void);
+def uiNewSearchEntry():
+    """
+    Creates a new search entry.
+
+    :return: uiEntry
+    """
+
+    # Set return type
+    clibui.uiNewSearchEntry.restype = ctypes.POINTER(uiEntry)
+
+    return clibui.uiNewSearchEntry()

--- a/pylibui/libui/entry.py
+++ b/pylibui/libui/entry.py
@@ -89,7 +89,7 @@ def uiEntrySetReadOnly(entry, read_only):
     Sets whether the entry is read only or not.
 
     :param entry: uiEntry
-    :param read_only: bool
+    :param read_only: int
     :return: None
     """
 

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -1,0 +1,43 @@
+"""
+ Pylibui test suite.
+
+"""
+
+from pylibui.controls import Entry, PasswordEntry, SearchEntry
+from tests.utils import WindowTestCase
+
+
+class EntryTest(WindowTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.entry = Entry()
+        self.password_entry = PasswordEntry()
+        self.search_entry = SearchEntry()
+
+    def test_text_initial_value(self):
+        """Tests the entry's `text` initial value is empty."""
+        self.assertEqual(self.entry.getText(), '')
+
+    def test_text_can_be_changed(self):
+        """Tests the entry's `text` attribute can be changed."""
+        text = 'My entry'
+        self.entry.setText(text)
+        self.assertEqual(self.entry.getText(), text)
+
+    def test_read_only_initial_value(self):
+        """Tests the entry's `read_only` initial value is False."""
+        self.assertEqual(self.entry.getReadOnly(), False)
+
+    def test_read_only_can_be_set_to_true(self):
+        """Tests the entry's `read_only` attribute can be set to True."""
+        self.entry.setReadOnly(True)
+        self.assertEqual(self.entry.getReadOnly(), True)
+
+    def test_read_only_can_be_set_to_false(self):
+        """Tests the entry's `read_only` attribute can be set to False."""
+        self.entry.setReadOnly(False)
+        self.assertEqual(self.entry.getReadOnly(), False)
+
+    def test_onChanged_is_called(self):
+        raise  # TODO: how do we simulate mouse press ?

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -12,8 +12,6 @@ class EntryTest(WindowTestCase):
     def setUp(self):
         super().setUp()
         self.entry = Entry()
-        self.password_entry = PasswordEntry()
-        self.search_entry = SearchEntry()
 
     def test_text_initial_value(self):
         """Tests the entry's `text` initial value is empty."""


### PR DESCRIPTION
I added uiEntries + fixed a wrong function call in `pylibui/libui/checkbox.py`

In the file `examples/entry.py`, I temporarily commented `app.close()` to avoid crashes (and added a comment that links to the issue #18)

Note: the deletion of "raise" in tests is already done in another branch ([here](https://github.com/superzazu/pylibui/tree/remove_raises_in_tests)). I'll make more PR (this one among two others which fixes #23 & #24) when this one is merged

What do you guys think ?