### PR TITLE
Removed unwanted casts in wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pylibui
 
-Python3 wrapper for [libui](https://github.com/andlabs/libui/). It uses ctypes 
+Python3 wrapper for [libui](https://github.com/andlabs/libui/). It uses ctypes
 to interface with the libui shared library.
 
 
@@ -21,7 +21,7 @@ class MyWindow(Window):
 app = App()
 
 window = MyWindow('Window', 800, 600)
-window.setMargined(1)
+window.setMargined(True)
 window.show()
 
 app.start()
@@ -35,7 +35,7 @@ Clone pylibui:
 
     $ git clone https://github.com/joaoventura/pylibui
 
-Clone [libui](https://github.com/andlabs/libui/) and build the shared library: 
+Clone [libui](https://github.com/andlabs/libui/) and build the shared library:
 
     $ git clone https://github.com/andlabs/libui/
     $ cd libui
@@ -44,7 +44,7 @@ Clone [libui](https://github.com/andlabs/libui/) and build the shared library:
     $ cmake ..
     $ make
 
-The libui shared library will be inside libui/build/out. Copy the contents of out/ 
+The libui shared library will be inside libui/build/out. Copy the contents of out/
 to pylibui/libui/sharedlibs. Now, you can use pylibui:
 
     $ python3
@@ -53,45 +53,45 @@ to pylibui/libui/sharedlibs. Now, you can use pylibui:
 
 ## Run Tests
 
-The tests are located in the `tests` folder. To run the entire test suite 
-execute the following in the outer pylibui directory: 
+The tests are located in the `tests` folder. To run the entire test suite
+execute the following in the outer pylibui directory:
 
     $ python3 -m unittest
     ..
     ----------------------------------------------------------------------
     Ran 20 tests in 0.055s
-    
+
     Ok
 
 To execute a single test file:
- 
+
     $ python3 -m unittest tests/test_window.py
     ..
     ----------------------------------------------------------------------
     Ran 2 tests in 0.033s
-    
+
     Ok
-    
+
 
 ## Contributing
 
 The project is divided in two major sections:
 
-* pylibui.libui: a ctypes wrapper around the libui C shared library. 
+* pylibui.libui: a ctypes wrapper around the libui C shared library.
 * pylibui: an object oriented pythonic wrapper that makes calls to pylibui.libui.
- 
-If you want to contribute, these are the two places that you can implement some
-code and make a pull request. 
 
-If the functionality you are looking for is still not implemented in the 
+If you want to contribute, these are the two places that you can implement some
+code and make a pull request.
+
+If the functionality you are looking for is still not implemented in the
 pylibui.libui ctypes wrapper, there's two things you may need to do:
 
 * Implement the function if the function header is already declared (it will have
 a TODO in there).
-* Generate the function. Use the bindings.py script in scripts/ to generate most 
-of the function declarations for a given section of the "ui.h" header file. 
- 
-If you need to use the bindings.py file, just run it changing the section that 
+* Generate the function. Use the bindings.py script in scripts/ to generate most
+of the function declarations for a given section of the "ui.h" header file.
+
+If you need to use the bindings.py file, just run it changing the section that
 you want to generate the bindings, copy-paste the contents to an empty file, and
 implement the ctypes calls. Most of them are easy, but you can check what's already
 done for some guidance.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pylibui
 
-Python3 wrapper for [libui](https://github.com/andlabs/libui/). It uses ctypes
+Python3 wrapper for [libui](https://github.com/andlabs/libui/). It uses ctypes 
 to interface with the libui shared library.
 
 
@@ -35,7 +35,7 @@ Clone pylibui:
 
     $ git clone https://github.com/joaoventura/pylibui
 
-Clone [libui](https://github.com/andlabs/libui/) and build the shared library:
+Clone [libui](https://github.com/andlabs/libui/) and build the shared library: 
 
     $ git clone https://github.com/andlabs/libui/
     $ cd libui
@@ -44,7 +44,7 @@ Clone [libui](https://github.com/andlabs/libui/) and build the shared library:
     $ cmake ..
     $ make
 
-The libui shared library will be inside libui/build/out. Copy the contents of out/
+The libui shared library will be inside libui/build/out. Copy the contents of out/ 
 to pylibui/libui/sharedlibs. Now, you can use pylibui:
 
     $ python3
@@ -53,45 +53,45 @@ to pylibui/libui/sharedlibs. Now, you can use pylibui:
 
 ## Run Tests
 
-The tests are located in the `tests` folder. To run the entire test suite
-execute the following in the outer pylibui directory:
+The tests are located in the `tests` folder. To run the entire test suite 
+execute the following in the outer pylibui directory: 
 
     $ python3 -m unittest
     ..
     ----------------------------------------------------------------------
     Ran 20 tests in 0.055s
-
+    
     Ok
 
 To execute a single test file:
-
+ 
     $ python3 -m unittest tests/test_window.py
     ..
     ----------------------------------------------------------------------
     Ran 2 tests in 0.033s
-
+    
     Ok
-
+    
 
 ## Contributing
 
 The project is divided in two major sections:
 
-* pylibui.libui: a ctypes wrapper around the libui C shared library.
+* pylibui.libui: a ctypes wrapper around the libui C shared library. 
 * pylibui: an object oriented pythonic wrapper that makes calls to pylibui.libui.
-
+ 
 If you want to contribute, these are the two places that you can implement some
-code and make a pull request.
+code and make a pull request. 
 
-If the functionality you are looking for is still not implemented in the
+If the functionality you are looking for is still not implemented in the 
 pylibui.libui ctypes wrapper, there's two things you may need to do:
 
 * Implement the function if the function header is already declared (it will have
 a TODO in there).
-* Generate the function. Use the bindings.py script in scripts/ to generate most
-of the function declarations for a given section of the "ui.h" header file.
-
-If you need to use the bindings.py file, just run it changing the section that
+* Generate the function. Use the bindings.py script in scripts/ to generate most 
+of the function declarations for a given section of the "ui.h" header file. 
+ 
+If you need to use the bindings.py file, just run it changing the section that 
 you want to generate the bindings, copy-paste the contents to an empty file, and
 implement the ctypes calls. Most of them are easy, but you can check what's already
 done for some guidance.

--- a/examples/button.py
+++ b/examples/button.py
@@ -26,7 +26,7 @@ class MyButton(Button):
 app = App()
 
 window = MyWindow('Window', 800, 600)
-window.setMargined(1)
+window.setMargined(True)
 
 button = MyButton('click me')
 window.setChild(button)

--- a/examples/checkbox.py
+++ b/examples/checkbox.py
@@ -23,7 +23,7 @@ class MyCheckbox(Checkbox):
 app = App()
 
 window = MyWindow('Checkbox example')
-window.setMargined(1)
+window.setMargined(True)
 
 checkbox = MyCheckbox('a checkbox!')
 checkbox.setText('a checkbox')

--- a/examples/combobox.py
+++ b/examples/combobox.py
@@ -23,7 +23,7 @@ class MyCombobox(Combobox):
 app = App()
 
 window = MyWindow('Window', 800, 600)
-window.setMargined(1)
+window.setMargined(True)
 
 combobox = MyCombobox()
 combobox.append("Blue")

--- a/examples/entry.py
+++ b/examples/entry.py
@@ -27,14 +27,14 @@ class MyEntry(Entry):
 app = App()
 
 window = MyWindow('Entry example')
-window.setMargined(1)
+window.setMargined(True)
 
 entry = MyEntry()
 search_entry = SearchEntry()
 password_entry = PasswordEntry()
 
 vbox = VerticalBox()
-vbox.setPadded(1)
+vbox.setPadded(True)
 vbox.append(entry)
 vbox.append(search_entry)
 vbox.append(password_entry)

--- a/examples/progressbar.py
+++ b/examples/progressbar.py
@@ -17,7 +17,7 @@ class MyWindow(Window):
 app = App()
 
 window = MyWindow('Progress bar example')
-window.setMargined(1)
+window.setMargined(True)
 
 progressbar = ProgressBar()
 progressbar.setValue(60)

--- a/examples/slider.py
+++ b/examples/slider.py
@@ -23,7 +23,7 @@ class MySlider(Slider):
 app = App()
 
 window = MyWindow('Window', 800, 600)
-window.setMargined(1)
+window.setMargined(True)
 
 slider = MySlider(0, 100)
 slider.setValue(50)

--- a/examples/spinbox.py
+++ b/examples/spinbox.py
@@ -17,7 +17,7 @@ class MyWindow(Window):
 app = App()
 
 window = MyWindow('Window', 800, 600)
-window.setMargined(1)
+window.setMargined(True)
 
 spinbox = Spinbox(0, 100)
 window.setChild(spinbox)

--- a/examples/tab.py
+++ b/examples/tab.py
@@ -17,7 +17,7 @@ class MyWindow(Window):
 app = App()
 
 window = MyWindow('Window', 400, 300)
-window.setMargined(1)
+window.setMargined(True)
 
 tab = Tab()
 
@@ -31,10 +31,10 @@ tabPage1.append(labelPage1)
 tabPage2.append(labelPage2)
 
 tab.append("Page 1", tabPage1)
-tab.setMargined(0, 1)
+tab.setMargined(0, True)
 
 tab.append("Page 2", tabPage2)
-tab.setMargined(1, 0)
+tab.setMargined(1, False)
 
 print("Number of pages: " + str(tab.getNumPages()))
 

--- a/examples/vbox.py
+++ b/examples/vbox.py
@@ -24,12 +24,12 @@ class MyButton(Button):
 app = App()
 
 window = MyWindow('Window', 800, 600)
-window.setMargined(1)
+window.setMargined(True)
 
 delete = MyButton("Delete 'Hello World!'")
 
 vbox = VerticalBox()
-vbox.setPadded(1)
+vbox.setPadded(True)
 window.setChild(vbox)
 
 vbox.append(Label('Hello World!'))

--- a/examples/window.py
+++ b/examples/window.py
@@ -17,7 +17,7 @@ class MyWindow(Window):
 app = App()
 
 window = MyWindow('Window', 800, 600)
-window.setMargined(1)
+window.setMargined(True)
 window.show()
 
 app.start()

--- a/pylibui/controls/button.py
+++ b/pylibui/controls/button.py
@@ -29,7 +29,7 @@ class Button(Control):
         """
         Sets the text of the button.
 
-        :param text: the text of the button
+        :param text: string
         :return: None
         """
         libui.uiButtonSetText(self.control, text)

--- a/pylibui/controls/checkbox.py
+++ b/pylibui/controls/checkbox.py
@@ -56,7 +56,7 @@ class Checkbox(Control):
 
         :return: bool
         """
-        return libui.uiCheckboxChecked(self.control)
+        return bool(libui.uiCheckboxChecked(self.control))
 
     def onToggled(self, data):
         """

--- a/pylibui/controls/checkbox.py
+++ b/pylibui/controls/checkbox.py
@@ -48,7 +48,7 @@ class Checkbox(Control):
         :param checked: bool
         :return: None
         """
-        libui.uiCheckboxSetChecked(self.control, checked)
+        libui.uiCheckboxSetChecked(self.control, int(checked))
 
     def getChecked(self):
         """

--- a/pylibui/controls/combobox.py
+++ b/pylibui/controls/combobox.py
@@ -26,7 +26,7 @@ class Combobox(Control):
 
     def append(self, text):
         """
-        Appends a new to the combobox.
+        Appends a new item to the combobox.
 
         :param text: string
         :return: None

--- a/pylibui/controls/control.py
+++ b/pylibui/controls/control.py
@@ -53,7 +53,7 @@ class Control:
 
         :return: bool
         """
-        return libui.uiControlEnabled(self.pointer())
+        return bool(libui.uiControlEnabled(self.pointer()))
 
     def setEnabled(self, enabled):
         """

--- a/pylibui/controls/control.py
+++ b/pylibui/controls/control.py
@@ -29,7 +29,7 @@ class Control:
 
         :return: bool
         """
-        return libui.uiControlVisible(self.control)
+        return bool(libui.uiControlVisible(self.control))
 
     def show(self):
         """

--- a/pylibui/controls/entry.py
+++ b/pylibui/controls/entry.py
@@ -33,7 +33,7 @@ class BaseEntry(Control):
         :param read_only: bool
         :return: None
         """
-        libui.uiEntrySetReadOnly(self.control, read_only)
+        libui.uiEntrySetReadOnly(self.control, int(read_only))
 
     def getReadOnly(self):
         """

--- a/pylibui/controls/entry.py
+++ b/pylibui/controls/entry.py
@@ -41,7 +41,7 @@ class BaseEntry(Control):
 
         :return: bool
         """
-        return libui.uiEntryReadOnly(self.control)
+        return bool(libui.uiEntryReadOnly(self.control))
 
     def onChanged(self, data):
         """

--- a/pylibui/controls/tab.py
+++ b/pylibui/controls/tab.py
@@ -49,22 +49,22 @@ class Tab(Control):
 
     def setMargined(self, page, margined):
         """
-        Sets the margins of the tab.
+        Sets whether the tab's page is margined or not.
 
         :param page: int
-        :param margined: int
+        :param margined: bool
         :return: None
         """
-        libui.uiTabSetMargined(self.control, page, margined)
+        libui.uiTabSetMargined(self.control, page, int(margined))
 
     def getMargined(self, page):
         """
-        Returns the margins of the tab.
+        Returns whether the tab's page is margined or not.
 
         :param page: int
-        :return: int
+        :return: bool
         """
-        return libui.uiTabMargined(self.control, page)
+        return bool(libui.uiTabMargined(self.control, page))
 
     def getNumPages(self):
         """

--- a/pylibui/controls/window.py
+++ b/pylibui/controls/window.py
@@ -128,7 +128,7 @@ class Window(Control):
         :param fullscreen: bool
         :return: None
         """
-        libui.uiWindowSetFullscreen(self.control, fullscreen)
+        libui.uiWindowSetFullscreen(self.control, int(fullscreen))
 
     def onContentSizeChange(self, data):
         """
@@ -163,7 +163,7 @@ class Window(Control):
         :param borderless: bool
         :return: None
         """
-        libui.uiWindowSetBorderless(self.control, borderless)
+        libui.uiWindowSetBorderless(self.control, int(borderless))
 
     def setChild(self, child):
         """
@@ -176,17 +176,17 @@ class Window(Control):
 
     def getMargined(self):
         """
-        Returns the window's margins.
+        Returns whether the window is margined or not.
 
-        :return: int
+        :return: bool
         """
-        return libui.uiWindowMargined(self.control)
+        return bool(libui.uiWindowMargined(self.control))
 
     def setMargined(self, margined):
         """
-        Sets the window's margins.
+        Sets whether the window is margined or not.
 
-        :param margined: int
+        :param margined: bool
         :return: None
         """
-        libui.uiWindowSetMargined(self.control, margined)
+        libui.uiWindowSetMargined(self.control, int(margined))

--- a/pylibui/controls/window.py
+++ b/pylibui/controls/window.py
@@ -119,7 +119,7 @@ class Window(Control):
 
         :return: bool
         """
-        return libui.uiWindowFullscreen(self.control)
+        return bool(libui.uiWindowFullscreen(self.control))
 
     def setFullscreen(self, fullscreen):
         """
@@ -154,7 +154,7 @@ class Window(Control):
 
         :return: bool
         """
-        return libui.uiWindowBorderless(self.control)
+        return bool(libui.uiWindowBorderless(self.control))
 
     def setBorderless(self, borderless):
         """

--- a/pylibui/libui/checkbox.py
+++ b/pylibui/libui/checkbox.py
@@ -77,10 +77,10 @@ def uiCheckboxChecked(checkbox):
     Returns whether the checkbox is checked or not.
 
     :param checkbox: uiCheckbox
-    :return: string
+    :return: int
     """
 
-    return bool(clibui.uiCheckboxChecked(checkbox))
+    return clibui.uiCheckboxChecked(checkbox)
 
 
 # - void uiCheckboxSetChecked(uiCheckbox *c, int checked);
@@ -89,7 +89,7 @@ def uiCheckboxSetChecked(checkbox, checked):
     Sets whether the checkbox is checked or not.
 
     :param checkbox: uiCheckbox
-    :param checked: bool
+    :param checked: int
     :return: None
     """
 

--- a/pylibui/libui/control.py
+++ b/pylibui/libui/control.py
@@ -67,7 +67,7 @@ def uiControlVisible(control):
     Returns whether the control is visible.
 
     :param control: uiControl
-    :return: uiControl
+    :return: int
     """
 
     return clibui.uiControlVisible(control)

--- a/pylibui/libui/control.py
+++ b/pylibui/libui/control.py
@@ -103,10 +103,10 @@ def uiControlEnabled(control):
     Returns whether a control is enabled.
 
     :param control: uiControl object
-    :return: bool
+    :return: int
     """
 
-    return bool(clibui.uiControlEnabled(control))
+    return clibui.uiControlEnabled(control)
 
 
 # - void uiControlEnable(uiControl *);

--- a/pylibui/libui/entry.py
+++ b/pylibui/libui/entry.py
@@ -77,10 +77,10 @@ def uiEntryReadOnly(entry):
     Returns whether the entry is read only or not.
 
     :param entry: uiEntry
-    :return: string
+    :return: int
     """
 
-    return bool(clibui.uiEntryReadOnly(entry))
+    return clibui.uiEntryReadOnly(entry)
 
 
 # - void uiEntrySetReadOnly(uiEntry *e, int readonly);

--- a/pylibui/libui/window.py
+++ b/pylibui/libui/window.py
@@ -164,7 +164,7 @@ def uiWindowSetFullscreen(window, fullscreen):
     Sets whether the window is in fullscreen.
 
     :param window: uiWindow
-    :param fullscreen: bool
+    :param fullscreen: int
     :return: None
     """
 
@@ -229,7 +229,7 @@ def uiWindowSetBorderless(window, borderless):
     Sets whether the window is borderless.
 
     :param window: uiWindow
-    :param borderless: bool
+    :param borderless: int
     :return: None
     """
 

--- a/pylibui/libui/window.py
+++ b/pylibui/libui/window.py
@@ -152,10 +152,10 @@ def uiWindowFullscreen(window):
     Returns whether the window is in fullscreen.
 
     :param window: uiWindow
-    :return: bool
+    :return: int
     """
 
-    return bool(clibui.uiWindowFullscreen(window))
+    return clibui.uiWindowFullscreen(window)
 
 
 # - void uiWindowSetFullscreen(uiWindow *w, int fullscreen);
@@ -217,10 +217,10 @@ def uiWindowBorderless(window):
     Returns whether the window is borderless.
 
     :param window: uiWindow
-    :return: bool
+    :return: int
     """
 
-    return bool(clibui.uiWindowBorderless(window))
+    return clibui.uiWindowBorderless(window)
 
 
 # - void uiWindowSetBorderless(uiWindow *w, int borderless);

--- a/tests/test_tab.py
+++ b/tests/test_tab.py
@@ -51,11 +51,11 @@ class TabTest(WindowTestCase):
         # self.tab.delete(40) # non-existing page index
 
     def test_margins_initial_value(self):
-        """Tests the tab's `margin` initial value is zero."""
+        """Tests the tab's `margin` initial value is False."""
         button = Button('my button')
         self.tab.append('my tab 1', button)
 
-        self.assertEqual(self.tab.getMargined(0), 0)
+        self.assertEqual(self.tab.getMargined(0), False)
 
     def test_margins_can_be_changed(self):
         """Tests the tab's `margin` attribute can be changed."""
@@ -63,9 +63,8 @@ class TabTest(WindowTestCase):
         button = Button('my button')
         self.tab.append('my tab 1', button)
 
-        margin = 20
-        self.tab.setMargined(0, margin)
-        self.assertEqual(self.tab.getMargined(0), margin)
+        self.tab.setMargined(0, True)
+        self.assertEqual(self.tab.getMargined(0), True)
 
         # TODO: should we do a check on indexes when user calls `getMargined` +
         #       `setMargined` ? At the moment, the following code crashes:


### PR DESCRIPTION
Okay, so I removed all the casts from wrappers and put them in controls instead. The only casts I left are the "bytes <-> string" ones (because we did not mention them in the issue, and I think it makes sense to have them here). 

Secondly, setMargined/getMargined/setPadded/getPadded (in classes Window/Box/Tab) all use boolean values, so I added the according casts in controls. I also modified accordingly the doctrings, examples, tests and the README file.

I also fixed a couple of typos in random docstrings.