### PR TITLE
fixed error on Entry components

### DIFF
--- a/examples/entry.py
+++ b/examples/entry.py
@@ -43,4 +43,4 @@ window.setChild(vbox)
 window.show()
 
 app.start()
-# app.close() # SEE https://github.com/joaoventura/pylibui/issues/18
+app.close()

--- a/pylibui/controls/entry.py
+++ b/pylibui/controls/entry.py
@@ -71,7 +71,7 @@ class Entry(BaseEntry):
                                                      None)
 
 
-class PasswordEntry(Entry):
+class PasswordEntry(BaseEntry):
 
     def __init__(self):
         """
@@ -89,7 +89,7 @@ class PasswordEntry(Entry):
                                                      None)
 
 
-class SearchEntry(Entry):
+class SearchEntry(BaseEntry):
 
     def __init__(self):
         """


### PR DESCRIPTION
Related to #18: the error* happen on quitting, when one widget has been instanced but is not "appended" to anything else (such as a box or a window).

When implementing the interface for uiEntry, I've made a mistake, where PasswordEntry and SearchEntry both inherited from "Entry" instead of "BaseEntry": meaning that for each PasswordEntry/SearchEntry, two Entries were created (one Entry, and one Password|SearchEntry). This led to the crash each time we used SearchEntry/PasswordEntry classes.

This commit fixes this mistake; there is no more error/crash when running `example/entry.py` for example.

* side note: as of today, the problem is still here:
```
from pylibui.core import App
from pylibui.controls import Window, Button


class MyWindow(Window):

    def onClose(self, data):
        super().onClose(data)
        app.stop()

app = App()

window = MyWindow('bug')

button = Button('hello')

# window.setChild(button) # no crashes if uncommenting this line
window.show()

app.start()
app.close()
```