### PR TITLE
add compiled lib to package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_script:
   - export BASE_DIR=$PWD && cd `mktemp -d` && export TEMP_LIB_DIR=$PWD && git clone https://github.com/andlabs/libui . && mkdir build && cd build && cmake .. && make && cd $BASE_DIR
 
 script:
-  - mkdir pylibui/libui/sharedlibs
+  - if [ ! -d pylibui/libui/sharedlibs ]; then mkdir pylibui/libui/sharedlibs ; fi
   - cp -f $TEMP_LIB_DIR/build/out/* pylibui/libui/sharedlibs/
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then xvfb-run python -m unittest ; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then python -m unittest ; fi

--- a/pylibui/libui/sharedlibs/__init__.py
+++ b/pylibui/libui/sharedlibs/__init__.py
@@ -1,0 +1,2 @@
+# This file is left empty
+

--- a/setup.py
+++ b/setup.py
@@ -5,5 +5,7 @@ setup(
     name='pylibui',
     version='0.0.1',
     description='Python wrapper for libui',
-    packages=find_packages()
+    packages=find_packages(),
+    package_data={'pylibui.libui.sharedlibs': '*'},
+    include_package_data=True,
 )


### PR DESCRIPTION
One shall expect the compiled libraries to be placed in installed path (one could also put soft links if he/she needs to 'share' it) , since otherwise python will complain about the missing dynamic lib. 